### PR TITLE
Stringify nulled $json variable

### DIFF
--- a/src/Setting.php
+++ b/src/Setting.php
@@ -225,7 +225,7 @@ class Setting {
             ->whereRaw($constraint_query)
             ->value($this->column);
 
-        $this->settings[$constraint_value] = json_decode($json, true);
+        $this->settings[$constraint_value] = json_decode((string) $json, true);
 
         $this->dirty[$constraint_value] = false;
         $this->loaded[$constraint_value] = true;


### PR DESCRIPTION
For no apparent reason the json_decode() in load() started to throw an error recently. 
It's true, as I set the values for the first time for a new user the $json returns null. But this should not throw an error (which it did: "json_decode() expects parameter 1 to be string, null given"). This fixes this.